### PR TITLE
feat(draftly): surround selected text with inlint styling

### DIFF
--- a/packages/draftly/package.json
+++ b/packages/draftly/package.json
@@ -63,6 +63,12 @@
       "require": "./dist/preview/index.cjs",
       "default": "./dist/preview/index.js"
     },
+    "./lib": {
+      "types": "./dist/lib/index.d.ts",
+      "import": "./dist/lib/index.js",
+      "require": "./dist/lib/index.cjs",
+      "default": "./dist/lib/index.js"
+    },
     "./src": {
       "types": "./src/index.ts",
       "default": "./src/index.ts"

--- a/packages/draftly/src/index.ts
+++ b/packages/draftly/src/index.ts
@@ -2,3 +2,4 @@
 export * from "./editor";
 export * from "./plugins";
 export * from "./preview";
+export * from "./lib";

--- a/packages/draftly/src/lib/index.ts
+++ b/packages/draftly/src/lib/index.ts
@@ -1,0 +1,2 @@
+export { createWrapSelectionInputHandler } from "./input-handler";
+export type { WrapSelectionMarkerMap } from "./input-handler";

--- a/packages/draftly/src/lib/input-handler.ts
+++ b/packages/draftly/src/lib/input-handler.ts
@@ -1,0 +1,45 @@
+import { EditorSelection, Extension } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+
+/**
+ * Mapping of typed input characters to surrounding markers.
+ *
+ * Example:
+ * { "*": "*", "=": "==" }
+ */
+export type WrapSelectionMarkerMap = Record<string, string>;
+
+/**
+ * Creates an input handler that wraps non-empty selections with markdown markers
+ * when a mapped character is typed.
+ */
+export function createWrapSelectionInputHandler(markersByInput: WrapSelectionMarkerMap): Extension {
+  return EditorView.inputHandler.of((view, _from, _to, text) => {
+    const marker = markersByInput[text];
+    if (!marker) {
+      return false;
+    }
+
+    const ranges = view.state.selection.ranges;
+    if (ranges.length === 0 || ranges.some((range) => range.empty)) {
+      return false;
+    }
+
+    const changes = ranges
+      .map((range) => ({
+        from: range.from,
+        to: range.to,
+        insert: `${marker}${view.state.sliceDoc(range.from, range.to)}${marker}`,
+      }))
+      .reverse();
+
+    const nextRanges = ranges.map((range) => EditorSelection.range(range.from + marker.length, range.to + marker.length));
+
+    view.dispatch({
+      changes,
+      selection: EditorSelection.create(nextRanges, view.state.selection.mainIndex),
+    });
+
+    return true;
+  });
+}

--- a/packages/draftly/src/plugins/code-plugin.ts
+++ b/packages/draftly/src/plugins/code-plugin.ts
@@ -1,4 +1,5 @@
 import { Decoration, EditorView, KeyBinding, WidgetType } from "@codemirror/view";
+import { EditorSelection, Extension } from "@codemirror/state";
 import { syntaxTree } from "@codemirror/language";
 import { DecorationContext, DecorationPlugin } from "../editor/plugin";
 import { createTheme, toggleMarkdownStyle } from "../editor";
@@ -236,6 +237,48 @@ export class CodePlugin extends DecorationPlugin {
         run: (view) => this.toggleCodeBlock(view),
         preventDefault: true,
       },
+    ];
+  }
+
+  /**
+   * Intercepts backtick typing to wrap selected text as inline code.
+   *
+   * If user types '`' while text is selected, wraps each selected range
+   * with backticks (selected -> `selected`).
+   */
+  override getExtensions(): Extension[] {
+    return [
+      EditorView.inputHandler.of((view, _from, _to, text) => {
+        if (text !== "`") {
+          return false;
+        }
+
+        const ranges = view.state.selection.ranges;
+        if (ranges.length === 0 || ranges.some((range) => range.empty)) {
+          return false;
+        }
+
+        const marker = "`";
+
+        const changes = ranges
+          .map((range) => ({
+            from: range.from,
+            to: range.to,
+            insert: `${marker}${view.state.sliceDoc(range.from, range.to)}${marker}`,
+          }))
+          .reverse();
+
+        const nextRanges = ranges.map((range) =>
+          EditorSelection.range(range.from + marker.length, range.to + marker.length)
+        );
+
+        view.dispatch({
+          changes,
+          selection: EditorSelection.create(nextRanges, view.state.selection.mainIndex),
+        });
+
+        return true;
+      }),
     ];
   }
 

--- a/packages/draftly/src/plugins/code-plugin.ts
+++ b/packages/draftly/src/plugins/code-plugin.ts
@@ -1,5 +1,5 @@
 import { Decoration, EditorView, KeyBinding, WidgetType } from "@codemirror/view";
-import { EditorSelection, Extension } from "@codemirror/state";
+import { Extension } from "@codemirror/state";
 import { syntaxTree } from "@codemirror/language";
 import { DecorationContext, DecorationPlugin } from "../editor/plugin";
 import { createTheme, toggleMarkdownStyle } from "../editor";
@@ -7,6 +7,7 @@ import { SyntaxNode } from "@lezer/common";
 import { highlightCode } from "@lezer/highlight";
 import { languages } from "@codemirror/language-data";
 import { classHighlighter } from "@lezer/highlight";
+import { createWrapSelectionInputHandler } from "../lib";
 
 // ============================================================================
 // Constants
@@ -247,39 +248,7 @@ export class CodePlugin extends DecorationPlugin {
    * with backticks (selected -> `selected`).
    */
   override getExtensions(): Extension[] {
-    return [
-      EditorView.inputHandler.of((view, _from, _to, text) => {
-        if (text !== "`") {
-          return false;
-        }
-
-        const ranges = view.state.selection.ranges;
-        if (ranges.length === 0 || ranges.some((range) => range.empty)) {
-          return false;
-        }
-
-        const marker = "`";
-
-        const changes = ranges
-          .map((range) => ({
-            from: range.from,
-            to: range.to,
-            insert: `${marker}${view.state.sliceDoc(range.from, range.to)}${marker}`,
-          }))
-          .reverse();
-
-        const nextRanges = ranges.map((range) =>
-          EditorSelection.range(range.from + marker.length, range.to + marker.length)
-        );
-
-        view.dispatch({
-          changes,
-          selection: EditorSelection.create(nextRanges, view.state.selection.mainIndex),
-        });
-
-        return true;
-      }),
-    ];
+    return [createWrapSelectionInputHandler({ "`": "`" })];
   }
 
   /**

--- a/packages/draftly/src/plugins/inline-plugin.ts
+++ b/packages/draftly/src/plugins/inline-plugin.ts
@@ -1,4 +1,4 @@
-import { Decoration, KeyBinding } from "@codemirror/view";
+import { Decoration, EditorView, KeyBinding } from "@codemirror/view";
 import { syntaxTree } from "@codemirror/language";
 import { DecorationContext, DecorationPlugin } from "../editor/plugin";
 import { createTheme } from "../editor";
@@ -6,6 +6,7 @@ import { SyntaxNode } from "@lezer/common";
 import { toggleMarkdownStyle } from "../editor/utils";
 import { tags } from "@lezer/highlight";
 import type { MarkdownConfig, InlineParser } from "@lezer/markdown";
+import { EditorSelection, Extension } from "@codemirror/state";
 
 /**
  * Node types for inline styling in markdown
@@ -160,6 +161,50 @@ export class InlinePlugin extends DecorationPlugin {
         run: toggleMarkdownStyle("=="),
         preventDefault: true,
       },
+    ];
+  }
+
+  /**
+   * Intercepts inline marker typing to wrap selected text.
+   *
+   * If user types inline markers while text is selected, wraps each selected
+   * range with the appropriate marker:
+   * - * _ ~ ^ -> marker + selected + marker
+   * - = -> ==selected==
+   */
+  override getExtensions(): Extension[] {
+    return [
+      EditorView.inputHandler.of((view, _from, _to, text) => {
+        if (text !== "*" && text !== "_" && text !== "~" && text !== "^" && text !== "=") {
+          return false;
+        }
+
+        const marker = text === "=" ? "==" : text;
+
+        const ranges = view.state.selection.ranges;
+        if (ranges.length === 0 || ranges.some((range) => range.empty)) {
+          return false;
+        }
+
+        const changes = ranges
+          .map((range) => ({
+            from: range.from,
+            to: range.to,
+            insert: `${marker}${view.state.sliceDoc(range.from, range.to)}${marker}`,
+          }))
+          .reverse();
+
+        const nextRanges = ranges.map((range) =>
+          EditorSelection.range(range.from + marker.length, range.to + marker.length)
+        );
+
+        view.dispatch({
+          changes,
+          selection: EditorSelection.create(nextRanges, view.state.selection.mainIndex),
+        });
+
+        return true;
+      }),
     ];
   }
 

--- a/packages/draftly/src/plugins/inline-plugin.ts
+++ b/packages/draftly/src/plugins/inline-plugin.ts
@@ -1,4 +1,4 @@
-import { Decoration, EditorView, KeyBinding } from "@codemirror/view";
+import { Decoration, KeyBinding } from "@codemirror/view";
 import { syntaxTree } from "@codemirror/language";
 import { DecorationContext, DecorationPlugin } from "../editor/plugin";
 import { createTheme } from "../editor";
@@ -6,7 +6,8 @@ import { SyntaxNode } from "@lezer/common";
 import { toggleMarkdownStyle } from "../editor/utils";
 import { tags } from "@lezer/highlight";
 import type { MarkdownConfig, InlineParser } from "@lezer/markdown";
-import { EditorSelection, Extension } from "@codemirror/state";
+import { Extension } from "@codemirror/state";
+import { createWrapSelectionInputHandler } from "../lib";
 
 /**
  * Node types for inline styling in markdown
@@ -173,39 +174,7 @@ export class InlinePlugin extends DecorationPlugin {
    * - = -> ==selected==
    */
   override getExtensions(): Extension[] {
-    return [
-      EditorView.inputHandler.of((view, _from, _to, text) => {
-        if (text !== "*" && text !== "_" && text !== "~" && text !== "^" && text !== "=") {
-          return false;
-        }
-
-        const marker = text === "=" ? "==" : text;
-
-        const ranges = view.state.selection.ranges;
-        if (ranges.length === 0 || ranges.some((range) => range.empty)) {
-          return false;
-        }
-
-        const changes = ranges
-          .map((range) => ({
-            from: range.from,
-            to: range.to,
-            insert: `${marker}${view.state.sliceDoc(range.from, range.to)}${marker}`,
-          }))
-          .reverse();
-
-        const nextRanges = ranges.map((range) =>
-          EditorSelection.range(range.from + marker.length, range.to + marker.length)
-        );
-
-        view.dispatch({
-          changes,
-          selection: EditorSelection.create(nextRanges, view.state.selection.mainIndex),
-        });
-
-        return true;
-      }),
-    ];
+    return [createWrapSelectionInputHandler({ "*": "*", _: "_", "~": "~", "^": "^", "=": "==" })];
   }
 
   /**

--- a/packages/draftly/src/plugins/math-plugin.ts
+++ b/packages/draftly/src/plugins/math-plugin.ts
@@ -1,4 +1,5 @@
 import { Decoration, EditorView, WidgetType } from "@codemirror/view";
+import { EditorSelection, Extension } from "@codemirror/state";
 import { syntaxTree } from "@codemirror/language";
 import { DecorationContext, DecorationPlugin } from "../editor/plugin";
 import { createTheme } from "../editor";
@@ -277,6 +278,48 @@ export class MathPlugin extends DecorationPlugin {
    */
   override get theme() {
     return theme;
+  }
+
+  /**
+   * Intercepts dollar typing to wrap selected text as inline math.
+   *
+   * If user types '$' while text is selected, wraps each selected range
+   * with single dollars (selected -> $selected$).
+   */
+  override getExtensions(): Extension[] {
+    return [
+      EditorView.inputHandler.of((view, _from, _to, text) => {
+        if (text !== "$") {
+          return false;
+        }
+
+        const ranges = view.state.selection.ranges;
+        if (ranges.length === 0 || ranges.some((range) => range.empty)) {
+          return false;
+        }
+
+        const marker = "$";
+
+        const changes = ranges
+          .map((range) => ({
+            from: range.from,
+            to: range.to,
+            insert: `${marker}${view.state.sliceDoc(range.from, range.to)}${marker}`,
+          }))
+          .reverse();
+
+        const nextRanges = ranges.map((range) =>
+          EditorSelection.range(range.from + marker.length, range.to + marker.length)
+        );
+
+        view.dispatch({
+          changes,
+          selection: EditorSelection.create(nextRanges, view.state.selection.mainIndex),
+        });
+
+        return true;
+      }),
+    ];
   }
 
   /**

--- a/packages/draftly/src/plugins/math-plugin.ts
+++ b/packages/draftly/src/plugins/math-plugin.ts
@@ -1,5 +1,5 @@
 import { Decoration, EditorView, WidgetType } from "@codemirror/view";
-import { EditorSelection, Extension } from "@codemirror/state";
+import { Extension } from "@codemirror/state";
 import { syntaxTree } from "@codemirror/language";
 import { DecorationContext, DecorationPlugin } from "../editor/plugin";
 import { createTheme } from "../editor";
@@ -7,6 +7,7 @@ import { SyntaxNode } from "@lezer/common";
 import { tags } from "@lezer/highlight";
 import type { MarkdownConfig, InlineParser, BlockParser, Line, BlockContext } from "@lezer/markdown";
 import katex from "katex";
+import { createWrapSelectionInputHandler } from "../lib";
 // @ts-expect-error - raw import for CSS as string
 import katexCss from "katex/dist/katex.min.css?raw";
 
@@ -287,39 +288,7 @@ export class MathPlugin extends DecorationPlugin {
    * with single dollars (selected -> $selected$).
    */
   override getExtensions(): Extension[] {
-    return [
-      EditorView.inputHandler.of((view, _from, _to, text) => {
-        if (text !== "$") {
-          return false;
-        }
-
-        const ranges = view.state.selection.ranges;
-        if (ranges.length === 0 || ranges.some((range) => range.empty)) {
-          return false;
-        }
-
-        const marker = "$";
-
-        const changes = ranges
-          .map((range) => ({
-            from: range.from,
-            to: range.to,
-            insert: `${marker}${view.state.sliceDoc(range.from, range.to)}${marker}`,
-          }))
-          .reverse();
-
-        const nextRanges = ranges.map((range) =>
-          EditorSelection.range(range.from + marker.length, range.to + marker.length)
-        );
-
-        view.dispatch({
-          changes,
-          selection: EditorSelection.create(nextRanges, view.state.selection.mainIndex),
-        });
-
-        return true;
-      }),
-    ];
+    return [createWrapSelectionInputHandler({ "$": "$" })];
   }
 
   /**

--- a/packages/draftly/tsup.config.ts
+++ b/packages/draftly/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/editor/index.ts", "src/plugins/index.ts", "src/preview/index.ts"],
+  entry: ["src/index.ts", "src/editor/index.ts", "src/plugins/index.ts", "src/preview/index.ts", "src/lib/index.ts"],
   format: ["esm", "cjs"],
   dts: true,
   outDir: "dist",


### PR DESCRIPTION
Added a feature to enclose selected text with inline styling tags.

Works with all inline styles extending to inline code and inline math plugins.